### PR TITLE
Using Alien::TALib to find ta-lib installed or install it if is required

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,10 +2,12 @@ use strict;
 use warnings;
 use ExtUtils::MakeMaker;
 use PDL::Core::Dev;
+use Alien::TALib;
  
 # ta-lib detection taken from Finance::TA
 
-my $libs = $ENV{TALIB_LIBS};
+my $alien = Alien::TALib->new;
+my $libs = $ENV{TALIB_LIBS} || $alien->libs;
 if (!defined $libs) {
   $libs = `ta-lib-config --libs`;
   $libs =~ s/[\s\n\r]*$//;
@@ -13,7 +15,7 @@ if (!defined $libs) {
   $libs .= " -lta_lib" if $libs && $libs !~ /-lta_lib/;
 }
 
-my $cflags = $ENV{TALIB_CFLAGS};
+my $cflags = $ENV{TALIB_CFLAGS} || $alien->cflags;
 if (!defined $cflags) {
  $cflags = `ta-lib-config --cflags`;
  $cflags =~ s/[\s\n\r]*$//;
@@ -37,14 +39,17 @@ WriteMakefile(
   LICENSE       => 'perl',
   PREREQ_PM     => {
         'PDL' => 2.006,
+        'Alien::TALib' => 0.05,
   },
   BUILD_REQUIRES     => {
         'PDL' => 2.006,
         'Test::More' => 0,
         'Test::Number::Delta' => 0,
+        'Alien::TALib' => 0.05,
   },
   CONFIGURE_REQUIRES => {
         'PDL' => 2.006,
+        'Alien::TALib' => 0.05,
   },
   META_MERGE   => { 
       resources    => {


### PR DESCRIPTION
Hi KMX

I have updated Alien::TALib to revision 0.05 on CPAN. It has been tested on Windows with Strawberry Perl, Linux and Mac OSX. Now Alien::TALib checks if ta-lib-config is present and uses that, or checks if TALIB_CFLAGS/TALIB_LIBS is present during the build and uses that or if nothing is present and it cannot find the library it will then download the appropriate version (msvc.zip for MSWin32) and src.tar.gz for the others and build it and install it into the appropriate location. This installable location can be set by the user in 3 ways:
- $PREFIX environment
- --prefix commandline to ./Build.PL
- Module::Build's default prefix for bin installs which most likely will be /usr/local/ unless the user has changed it
  and 
- if none then a custom local lib directory using File::HomeDir->my_dist_data() call. 
  This way, the installed ta-lib-config will always be found regardless of where it has been installed if using Alien::TALib to find it.

Let me know if you like it.

Thanks
Vikas
